### PR TITLE
Fixed linking error on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,21 @@ add_executable(restserver
   )
 
 set(Casablanca_LIBRARIES "-lboost_system -lcrypto -lssl -lcpprest")
+set(LINKING_LIBRARIES ${Casablanca_LIBRARIES})
+
 if(DBMS)
 	set(NEW_DB_SRC_DIR ${CMAKE_SOURCE_DIR}/dbms/src)
 	add_library(dbms SHARED
 		${NEW_DB_SRC_DIR}/Dbms.cpp
 		)
 	set(Dbms_dep_lib "-lpqxx -lpq")
-	target_link_libraries(restserver dbms ${Casablanca_LIBRARIES} ${Dbms_dep_lib})
-else(DBMS)
-
-	target_link_libraries(restserver ${Casablanca_LIBRARIES})
+	set(LINKING_LIBRARIES ${LINKING_LIBRARIES} dbms ${Dbms_dep_lib})
 endif(DBMS)
 
 if (UNIX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+	# Linking POSIX threads
+	find_package(Threads REQUIRED)
+	set(LINKING_LIBRARIES ${LINKING_LIBRARIES} Threads::Threads)
 endif (UNIX)
+
+target_link_libraries(restserver PRIVATE ${LINKING_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ else(DBMS)
 	target_link_libraries(restserver ${Casablanca_LIBRARIES})
 endif(DBMS)
 
-
-
-
-
+if (UNIX)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif (UNIX)


### PR DESCRIPTION
Fixes the following build error:
```
/usr/bin/ld: CMakeFiles/restserver.dir/main.cpp.o: undefined reference to symbol 'pthread_cond_clockwait@@GLIBC_2.30'
/usr/bin/ld: /usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
Related issue: #12 